### PR TITLE
Add tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,53 @@
+name: Django CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: pass
+          POSTGRES_DB: db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U user -d db" --health-interval=10s --health-timeout=5s --health-retries=5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=5
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r src/requirements.txt
+    - name: Run tests
+      env:
+        POSTGRES_USER: user
+        POSTGRES_PASSWORD: pass
+        POSTGRES_DB: db
+        DB_HOST: localhost
+        DB_PORT: 5432
+        EMAIL_HOST: dummy
+        EMAIL_HOST_USER: dummy
+        EMAIL_HOST_PASSWORD: dummy
+        SERVER_EMAIL: noreply@example.com
+      run: |
+        python src/manage.py migrate --noinput
+        python src/manage.py test

--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ This repository contains a minimal example of running a Django **todo** applicat
 
 The `src` directory contains the Django project (`todoproject`) and the `todo` app with simple models, views and Celery tasks.
 
+## Running Tests
+
+Automated tests live inside the `src` directory. Execute them using Django's test runner:
+
+```bash
+python src/manage.py test
+```
+
+GitHub Actions run the same command on every push or pull request to the `main` branch.
+
 ---
 
 This README aims to provide enough information to get the containers running quickly. Feel free to modify the setup to suit your own development workflow.

--- a/src/todo/tests.py
+++ b/src/todo/tests.py
@@ -1,3 +1,56 @@
-from django.test import TestCase
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from unittest import mock
 
-# Create your tests here.
+from .models import Todo
+
+
+class TodoModelTestCase(TestCase):
+    def test_str_representation(self):
+        todo = Todo(name="Sample")
+        self.assertEqual(str(todo), "Sample")
+
+
+class TodoListViewTestCase(TestCase):
+    def setUp(self):
+        user_cls = get_user_model()
+        self.user = user_cls.objects.create_user(email="user@example.com", password="pass")
+        self.other = user_cls.objects.create_user(email="other@example.com", password="pass")
+        Todo.objects.create(name="Todo 1", profile=self.user.profile)
+        Todo.objects.create(name="Other Todo", profile=self.other.profile)
+        self.client = Client()
+
+    def test_login_required(self):
+        url = reverse("todo:todo_list")
+        response = self.client.get(url)
+        login_url = reverse("login")
+        self.assertRedirects(response, f"{login_url}?next={url}")
+
+    def test_list_shows_only_user_todos(self):
+        self.client.login(email="user@example.com", password="pass")
+        response = self.client.get(reverse("todo:todo_list"))
+        todos = list(response.context["object_list"].values_list("name", flat=True))
+        self.assertEqual(todos, ["Todo 1"])
+
+
+class SendTodoCreatedEmailTestCase(TestCase):
+    def setUp(self):
+        user_cls = get_user_model()
+        self.user = user_cls.objects.create_user(email="test@example.com", password="pass")
+        self.todo = Todo.objects.create(name="Task", profile=self.user.profile)
+
+    @mock.patch("todo.tasks.send_mail")
+    def test_email_sent(self, mocked_send_mail):
+        from .tasks import send_todo_created_email
+
+        send_todo_created_email(self.todo.id)
+
+        mocked_send_mail.assert_called_with(
+            subject=f"New todo: {self.todo.name}",
+            message=f"You just created a new todo:\n\n{self.todo.name}",
+            from_email=None,
+            recipient_list=[self.user.email],
+            fail_silently=False,
+        )
+


### PR DESCRIPTION
## Summary
- add Django unit tests for the todo app
- create a GitHub Actions workflow to run the test suite
- document how to run tests

## Testing
- `python src/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684cdeeb0f2883209b9d4ef514094750